### PR TITLE
Update references and extension 1 (lavaan)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -300,10 +300,7 @@ $(document).ready(function () {
 
 
 <hr />
-<div id="the-random-intercept-cross-lagged-panel-model" class="section level3">
-<h3>The Random Intercept Cross-Lagged Panel Model</h3>
-<p>The random intercept cross-lagged panel model (RI-CLPM) is rapidly gaining popularity as a structural equation modeling approach to longitudinal data. It allows for the decomposition of observed scores into within-person dynamics and between-person differences.</p>
-<p>This website is a supplement to “Three Extensions of the Random Intercept Cross-Lagged Panel Model” by Mulder and Hamaker (under review). It contains Mplus syntax and <em>lavaan</em> code for specifying the basic RI-CLPM and the following three extensions:</p>
+<p>This website is a supplement to “Three Extensions of the Random Intercept Cross-Lagged Panel Model” by <span class="citation">Mulder and Hamaker (2020)</span>. It contains Mplus syntax and <em>lavaan</em> code for specifying the basic RI-CLPM and the following three extensions:</p>
 <ol style="list-style-type: decimal">
 <li>including a time-invariant predictor and outcome,</li>
 <li>doing multiple group analysis, and</li>
@@ -311,7 +308,6 @@ $(document).ready(function () {
 </ol>
 <p>Use the top menu to navigate to the Mplus syntax or <em>lavaan</em> code. The <em>lavaan (R)</em> tab contains additional code for performing the <span class="math inline">\(\bar{\chi}^{2}\)</span>-test (chi-bar-square test) in R. This test is used for comparing nested models where the more parsimonious model is based on constraining parameters on the bound of the parameter space (e.g., constraining a variance to 0).</p>
 <hr />
-</div>
 <div id="data" class="section level3">
 <h3>Data</h3>
 <p>You can find simulated example datasets (1189 units, 5 repeated-measures) on <a href="https://github.com/ellenhamaker/RI-CLPM/tree/master/data">Github</a> to get hands-on experience with this modeling approach. The example data are motivated by <span class="citation">Narmandakh et al. (2020)</span> who obtained five waves of data from 1189 adolescents on their sleep problems and anxiety over 15 years.</p>
@@ -325,8 +321,11 @@ $(document).ready(function () {
 <div id="references" class="section level3 unnumbered">
 <h3>References</h3>
 <div id="refs" class="references">
+<div id="ref-Mulder2020">
+<p>Mulder, Jeroen D., and Ellen L. Hamaker. 2020. “Three Extensions of the Random Intercept Cross-Lagged Panel Model.” <em>Structural Equation Modeling: A Multidisciplinary Journal</em>. <a href="https://doi.org/10.1080/10705511.2020.1784738">https://doi.org/10.1080/10705511.2020.1784738</a>.</p>
+</div>
 <div id="ref-Narmandakh2020">
-<p>Narmandakh, Altanzul, Annelieke M. Roest, Peter de Jonge, and Albertine J. Oldehinkel. 2020. “The bidirectional association between sleep problems and anxiety symptoms in adolescents: a TRAILS report.” <em>Sleep Medicine</em> 67 (March): 39–46. doi:<a href="https://doi.org/10.1016/j.sleep.2019.10.018">10.1016/j.sleep.2019.10.018</a>.</p>
+<p>Narmandakh, Altanzul, Annelieke M. Roest, Peter de Jonge, and Albertine J. Oldehinkel. 2020. “The bidirectional association between sleep problems and anxiety symptoms in adolescents: a TRAILS report.” <em>Sleep Medicine</em> 67 (March): 39–46. <a href="https://doi.org/10.1016/j.sleep.2019.10.018">https://doi.org/10.1016/j.sleep.2019.10.018</a>.</p>
 </div>
 </div>
 </div>

--- a/docs/lavaan.html
+++ b/docs/lavaan.html
@@ -463,7 +463,7 @@ datMI &lt;- read.table(&quot;/Users/jeroenmulder/Git/RICLPM/data/RICLPM-MI.dat&q
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -516,7 +516,7 @@ summary(CLPM.fit, standardized = T)</code></pre>
 </div>
 <div id="constraints-over-time" class="section level3">
 <h3>Constraints over time</h3>
-<p>Imposing constraints to the model can be achieved through <strong>pre-multiplication</strong>. It means that we have to prepend the number that we want to fix the parameter to, and an asterisk, to the parameter in the model specification. For example, <code>F =~ 0*x1</code> fixes the factor loading of item <code>x1</code> to factor <code>F</code> to 0. Using pre-multiplication we can also constrain parameters to be the same by giving them the same label. Below we specify a RI-CLPM with the following constraints:</p>
+<p>Imposing constraints to the model can be achieved through <strong>pre-multiplication</strong>. It means that we have to prepend the number that we want to fix the parameter to, and an asterisk, to the parameter in the model specification. For example, <code>F =~ 0*x1</code> fixes the factor loading of item <code>x1</code> to factor <code>F</code> to 0. Using pre-multiplication we can also constrain parameters to be the same by giving them the same label. Below we specify an RI-CLPM with the following constraints:</p>
 <ol style="list-style-type: decimal">
 <li>fixed auto-regressive and cross-lagged relations over time, <code>wx2 ~ a*wx1 + b*wy1; ...</code>,</li>
 <li>time-invariant (residual) (co-)variances in the within-person part <code>wx2 ~~ cov*wy2; ...</code>, <code>wx2 ~~ vx*wx2; ...</code>, and <code>wy2 ~~ vy*wy2; ...</code>, and</li>
@@ -559,7 +559,7 @@ summary(CLPM.fit, standardized = T)</code></pre>
   # Estimate the covariance between the within-person centered variables at the first wave. 
   wx1 ~~ wy1 # Covariance
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -596,7 +596,7 @@ summary(RICLPM5.fit, standardized = T)</code></pre>
 </ul>
 <div id="z_1-predicting-observed" class="section level3">
 <h3><span class="math inline">\(z_{1}\)</span> predicting observed</h3>
-<p>Below you can find the code for a RI-CLPM with 5 waves and a time-invariant predictor <span class="math inline">\(z_{1}\)</span> for the observed variables. The effect of <span class="math inline">\(z_{1}\)</span> on the observed variables is constrained to be the same across waves.</p>
+<p>Below you can find the code for an RI-CLPM with 5 waves and a time-invariant predictor <span class="math inline">\(z_{1}\)</span> for the observed variables. The effect of <span class="math inline">\(z_{1}\)</span> on the observed variables is constrained to be the same across waves.</p>
 <pre class="r"><code>RICLPM.ext1 &lt;- &#39;
   # Create between components (random intercepts)
   RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
@@ -633,7 +633,7 @@ summary(RICLPM5.fit, standardized = T)</code></pre>
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -656,11 +656,19 @@ summary(RICLPM.ext1.fit, standardized = T)</code></pre>
 </div>
 <div id="z_1-predicting-ris" class="section level3">
 <h3><span class="math inline">\(z_{1}\)</span> predicting RIs</h3>
-<p>Below you can find the code for a RI-CLPM with 5 waves and a time-invariant predictor <span class="math inline">\(z_{1}\)</span> for the random intercepts.</p>
+<p>Below you can find the code for an RI-CLPM with 5 waves and a time-invariant predictor <span class="math inline">\(z_{1}\)</span> for the random intercepts.</p>
 <pre class="r"><code>RICLPM1.ext1 &lt;- &#39;
   # Create between components (random intercepts)
   RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
   RIy =~ 1*y1 + 1*y2 + 1*y3 + 1*y4 + 1*y5
+  
+  # Estimate the variance and covariance of the random intercepts. 
+  RIx ~~ RIx
+  RIy ~~ RIy
+  RIx ~~ RIy
+  
+  # Regression of random intercepts on z1. 
+  RIx + RIy ~ z1 # Constrained over time. 
   
   # Create within-person centered variables
   wx1 =~ 1*x1
@@ -673,10 +681,6 @@ summary(RICLPM.ext1.fit, standardized = T)</code></pre>
   wy3 =~ 1*y3
   wy4 =~ 1*y4
   wy5 =~ 1*y5
-  
-  # Regression of random intercepts on z1. 
-  RIx ~ z1 
-  RIy ~ z1 
   
   # Estimate the lagged effects between the within-person centered variables.
   wx2 + wy2 ~ wx1 + wy1
@@ -692,11 +696,6 @@ summary(RICLPM.ext1.fit, standardized = T)</code></pre>
   wx3 ~~ wy3
   wx4 ~~ wy4
   wx5 ~~ wy5
-  
-  # Estimate the variance and covariance of the individual factors. 
-  RIx ~~ RIx
-  RIy ~~ RIy
-  RIx ~~ RIy
   
   # Estimate the (residual) variance of the within-person centered variables.
   wx1 ~~ wx1 # Variances
@@ -716,11 +715,129 @@ summary(RICLPM1.ext1.fit, standardized = T)</code></pre>
 </div>
 <div id="ris-predicting-z_2" class="section level3">
 <h3>RI’s predicting <span class="math inline">\(z_{2}\)</span></h3>
-<p><em>lavaan</em> code will arrive soon for this model.</p>
+<p>Below you can find code for an RI-CLPM with the between components (the random intercepts) predicting a time-invariant outcome. For sake of completeness, the time-invariant <span class="math inline">\(z_{1}\)</span> is also included as a predictor the for observed variables (constrained).</p>
+<pre class="r"><code>RICLPM3.ext1 &lt;- &#39;
+  # Create between components (random intercepts)
+  RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
+  RIy =~ 1*y1 + 1*y2 + 1*y3 + 1*y4 + 1*y5
+  
+  # Estimate the variance and covariance of the random intercepts. 
+  RIx ~~ RIx
+  RIy ~~ RIy
+  RIx ~~ RIy
+  
+  # Regression of time-invariant outcome z2 on random intercepts.
+  z2 ~ RIx + RIy
+  z2 ~~ z2 # Residual variance z2
+  
+  # Create within-person centered variables
+  wx1 =~ 1*x1
+  wx2 =~ 1*x2
+  wx3 =~ 1*x3 
+  wx4 =~ 1*x4
+  wx5 =~ 1*x5
+  wy1 =~ 1*y1
+  wy2 =~ 1*y2
+  wy3 =~ 1*y3
+  wy4 =~ 1*y4
+  wy5 =~ 1*y5
+  
+  # Regression of observed variables on z1 (constrained). 
+  x1 + x2 + x3 + x4 + x5 ~ s1*z1 # Constrained over time. 
+  y1 + y2 + y3 + y4 + y5 ~ s2*z1 # Constrained over time. 
+  
+  # Estimate the lagged effects between the within-person centered variables.
+  wx2 + wy2 ~ wx1 + wy1
+  wx3 + wy3 ~ wx2 + wy2
+  wx4 + wy4 ~ wx3 + wy3
+  wx5 + wy5 ~ wx4 + wy4
+  
+  # Estimate the covariance between the within-person centered variables at the first wave. 
+  wx1 ~~ wy1 # Covariance
+  
+  # Estimate the covariances between the residuals of the within-person centered variables (the innovations).
+  wx2 ~~ wy2
+  wx3 ~~ wy3
+  wx4 ~~ wy4
+  wx5 ~~ wy5
+  
+  # Estimate the (residual) variance of the within-person centered variables.
+  wx1 ~~ wx1 # Variances
+  wy1 ~~ wy1 
+  wx2 ~~ wx2 # Residual variances
+  wy2 ~~ wy2 
+  wx3 ~~ wx3 
+  wy3 ~~ wy3 
+  wx4 ~~ wx4 
+  wy4 ~~ wy4 
+  wx5 ~~ wx5
+  wy5 ~~ wy5
+&#39;
+RICLPM3.ext1.fit &lt;- lavaan(RICLPM3.ext1, data = datZ, missing = &#39;ML&#39;, meanstructure = T, int.ov.free = T) 
+summary(RICLPM3.ext1.fit, standardized = T)</code></pre>
 </div>
 <div id="within-predicting-z_2" class="section level3">
 <h3>Within predicting <span class="math inline">\(z_{2}\)</span></h3>
-<p><em>lavaan</em> code will arrive soon for this model.</p>
+<p>Below you can find code for an RI-CLPM with the within components predicting a time-invariant outcome. For sake of completeness, the time-invariant <span class="math inline">\(z_{1}\)</span> is also included as a predictor the for observed variables (constrained).</p>
+<pre class="r"><code>RICLPM4.ext1 &lt;- &#39;
+  # Create between components (random intercepts)
+  RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
+  RIy =~ 1*y1 + 1*y2 + 1*y3 + 1*y4 + 1*y5
+  
+  # Estimate the variance and covariance of the random intercepts. 
+  RIx ~~ RIx
+  RIy ~~ RIy
+  RIx ~~ RIy
+  
+  # Regression of time-invariant outcome z2 on within components.
+  z2 ~ wx1 + wx2 + wx3 + wx4 + wx5 + wy1 + wy2 + wy3 + wy4 + wy5
+  z2 ~~ z2 # Residual variance z2
+  
+  # Create within-person centered variables
+  wx1 =~ 1*x1
+  wx2 =~ 1*x2
+  wx3 =~ 1*x3 
+  wx4 =~ 1*x4
+  wx5 =~ 1*x5
+  wy1 =~ 1*y1
+  wy2 =~ 1*y2
+  wy3 =~ 1*y3
+  wy4 =~ 1*y4
+  wy5 =~ 1*y5
+  
+  # Regression of observed variables on z1 (constrained). 
+  x1 + x2 + x3 + x4 + x5 ~ s1*z1 # Constrained over time. 
+  y1 + y2 + y3 + y4 + y5 ~ s2*z1 # Constrained over time. 
+  
+  # Estimate the lagged effects between the within-person centered variables.
+  wx2 + wy2 ~ wx1 + wy1
+  wx3 + wy3 ~ wx2 + wy2
+  wx4 + wy4 ~ wx3 + wy3
+  wx5 + wy5 ~ wx4 + wy4
+  
+  # Estimate the covariance between the within-person centered variables at the first wave. 
+  wx1 ~~ wy1 # Covariance
+  
+  # Estimate the covariances between the residuals of the within-person centered variables (the innovations).
+  wx2 ~~ wy2
+  wx3 ~~ wy3
+  wx4 ~~ wy4
+  wx5 ~~ wy5
+  
+  # Estimate the (residual) variance of the within-person centered variables.
+  wx1 ~~ wx1 # Variances
+  wy1 ~~ wy1 
+  wx2 ~~ wx2 # Residual variances
+  wy2 ~~ wy2 
+  wx3 ~~ wx3 
+  wy3 ~~ wy3 
+  wx4 ~~ wx4 
+  wy4 ~~ wy4 
+  wx5 ~~ wx5
+  wy5 ~~ wy5
+&#39;
+RICLPM4.ext1.fit &lt;- lavaan(RICLPM4.ext1, data = datZ, missing = &#39;ML&#39;, meanstructure = T, int.ov.free = T) 
+summary(RICLPM4.ext1.fit, standardized = T)</code></pre>
 </div>
 </div>
 <div id="ext.-2-multiple-group" class="section level2 tabset tabset-fade">
@@ -759,7 +876,7 @@ summary(RICLPM1.ext1.fit, standardized = T)</code></pre>
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -819,7 +936,7 @@ summary(RICLPM.ext2.fit)</code></pre>
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -1299,10 +1416,10 @@ ChiBar2DiffTest$p_value</code></pre>
 <p>Kuiper, Rebecca M. 2020. <em>ChiBarSq.DiffTest: Chi-bar-square difference test of the RI-CLPM versus the CLPM and more general.</em></p>
 </div>
 <div id="ref-lavaan">
-<p>Rosseel, Yves. 2012. “lavaan: An R Package for Structural Equation Modeling.” <em>Journal of Statistical Software</em> 48 (2): 1–36. <a href="http://www.jstatsoft.org/v48/i02/" class="uri">http://www.jstatsoft.org/v48/i02/</a>.</p>
+<p>Rosseel, Yves. 2012. “lavaan: An R Package for Structural Equation Modeling.” <em>Journal of Statistical Software</em> 48 (2): 1–36. <a href="http://www.jstatsoft.org/v48/i02/">http://www.jstatsoft.org/v48/i02/</a>.</p>
 </div>
 <div id="ref-Stoel2006">
-<p>Stoel, Reinoud D., Francisca Galindo Garre, Conor Dolan, and Godfried van den Wittenboer. 2006. “On the likelihood ratio test in structural equation modeling when parameters are subject to boundary constraints.” <em>Psychological Methods</em> 11 (4): 439–55. doi:<a href="https://doi.org/10.1037/1082-989X.11.4.439">10.1037/1082-989X.11.4.439</a>.</p>
+<p>Stoel, Reinoud D., Francisca Galindo Garre, Conor Dolan, and Godfried van den Wittenboer. 2006. “On the likelihood ratio test in structural equation modeling when parameters are subject to boundary constraints.” <em>Psychological Methods</em> 11 (4): 439–55. <a href="https://doi.org/10.1037/1082-989X.11.4.439">https://doi.org/10.1037/1082-989X.11.4.439</a>.</p>
 </div>
 </div>
 </div>

--- a/docs/mplus.html
+++ b/docs/mplus.html
@@ -376,7 +376,7 @@ div.tocify {
 <hr />
 <div id="setup" class="section level2">
 <h2>Setup</h2>
-<p>For Mplus <span class="citation">(Muthén L. K. and Muthén 2017)</span> to work properly, make sure that you save the input file with the model specification (<em>example.inp</em>) in the same folder as the data (<em>example.dat</em>). You can download the simulated example datasets <a href="https://github.com/ellenhamaker/RI-CLPM/tree/master/data">here</a>. Mplus includes defaults, like that:</p>
+<p>For Mplus <span class="citation">(Muthén and Muthén 2017)</span> to work properly, make sure that you save the input file with the model specification (<em>example.inp</em>) in the same folder as the data (<em>example.dat</em>). You can download the simulated example datasets <a href="https://github.com/ellenhamaker/RI-CLPM/tree/master/data">here</a>. Mplus includes defaults, like that:</p>
 <ul>
 <li>observed and latent exogenous variables are correlated, and</li>
 <li>residuals of observed and latent outcome variables (which do not predict anything) in a path model are correlated.</li>
@@ -1399,7 +1399,7 @@ OUTPUT:     TECH1 STDYX SAMPSTAT CINTERVAL;</code></pre>
 <h2>References</h2>
 <div id="refs" class="references">
 <div id="ref-Meredith1993">
-<p>Meredith, William. 1993. “Measurement invariance, factor analysis and factorial invariance.” <em>Psychometrika</em>. doi:<a href="https://doi.org/10.1007/BF02294825">10.1007/BF02294825</a>.</p>
+<p>Meredith, William. 1993. “Measurement invariance, factor analysis and factorial invariance.” <em>Psychometrika</em>. <a href="https://doi.org/10.1007/BF02294825">https://doi.org/10.1007/BF02294825</a>.</p>
 </div>
 <div id="ref-Mplus8">
 <p>Muthén, L. K., and B. O. Muthén. 2017. <em>Mplus User’s Guide</em>. Eighth Edition. Los Angeles, CA: Muthén &amp; Muthén.</p>

--- a/docs/p-references.bib
+++ b/docs/p-references.bib
@@ -763,3 +763,14 @@ title = {{From Data to Causes II: Comparing Approaches to Panel Data Analysis}},
 url = {http://journals.sagepub.com/doi/10.1177/1094428119847280},
 year = {2019}
 }
+
+@article{Mulder2020,
+  author = {Jeroen D. Mulder and Ellen L. Hamaker},
+  title = {Three Extensions of the Random Intercept Cross-Lagged Panel Model},
+  journal = {Structural Equation Modeling: A Multidisciplinary Journal},
+  year  = {2020},
+  publisher = {Routledge},
+  doi = {10.1080/10705511.2020.1784738},
+  URL = {https://doi.org/10.1080/10705511.2020.1784738},
+  eprint = {https://doi.org/10.1080/10705511.2020.1784738}
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -7,7 +7,8 @@
 	Edition = {Eighth Edition},
 	Organization = {Muth{\'e}n & Muth{\'e}n},
 	Title = {Mplus User's Guide},
-	Year = {2017}}
+	Year = {2017}
+}
 
 @article{lavaan,
 	Author = {Yves Rosseel},
@@ -18,7 +19,8 @@
 	Url = {http://www.jstatsoft.org/v48/i02/},
 	Volume = {48},
 	Year = {2012},
-	Bdsk-Url-1 = {http://www.jstatsoft.org/v48/i02/}}
+	Bdsk-Url-1 = {http://www.jstatsoft.org/v48/i02/}
+}
 
 @article{Meredith1993,
 	abstract = {Several concepts are introduced and defined: measurement invariance, structural bias, weak measurement invariance, strong factorial invariance, and strict factorial 			invariance. It is shown that factorial invariance has implications for (weak) measurement invariance. Definitions of fairness in employment/admissions testing and salary equity 				are provided and it 	is argued that strict factorial invariance is required for fairness/equity to exist. Implications for item and test bias are developed and it is argued that item or test bias probably depends on the existence of latent variables that are irrelevant to the primary goal of test constructers. {\textcopyright} 1993 The Psychometric Society.},
@@ -28,7 +30,8 @@
 	journal = {Psychometrika},
 	keywords = {equity,factor analysis,factorial invariance,fairness,group differences,item bias,measurement invariance,selection,test bias},
 	title = {{Measurement invariance, factor analysis and factorial invariance}},
-	year = {1993}}
+	year = {1993}
+}
 
 @manual{tidyverse,
 	Author = {Hadley Wickham},
@@ -36,7 +39,8 @@
 	Title = {tidyverse: Easily Install and Load the 'Tidyverse'},
 	Url = {https://CRAN.R-project.org/package=tidyverse},
 	Year = {2017},
-	Bdsk-Url-1 = {https://CRAN.R-project.org/package=tidyverse}}
+	Bdsk-Url-1 = {https://CRAN.R-project.org/package=tidyverse}
+}
 	
 @article{Stoel2006,
   abstract = {The authors show how the use of inequality constraints on parameters in structural equation models may affect the distribution of the likelihood ratio test. Inequality constraints are implicitly used in the testing of commonly applied structural equation models, such as the common factor model, the autoregressive model, and the latent growth curve model, although this is not commonly acknowledged. Such constraints are the result of the null hypothesis in which the parameter value or values are placed on the boundary of the parameter space. For instance, this occurs in testing whether the variance of a growth parameter is significantly different from 0. It is shown that in these cases, the asymptotic distribution of the chi-square difference cannot be treated as that of a central chi-square-distributed random variable with degrees of freedom equal to the number of constraints. The correct distribution for testing 1 or a few parameters at a time is inferred for the 3 structural equation models mentioned above. Subsequently, the authors describe and illustrate the steps that one should take to obtain this distribution. An important message is that using the correct distribution may lead to appreciably greater statistical power. {\textcopyright} 2006 APA, all rights reserved.},
@@ -54,9 +58,19 @@
 }
 
 @Manual{Kuiper2020,
-    title = {{ChiBarSq.DiffTest: Chi-bar-square difference test of the RI-CLPM versus the CLPM
-and more general.}},
-    author = {Rebecca M. Kuiper},
-    year = {2020},
-    note = {R package version 0.0.0.9000},
-  }
+  title = {{ChiBarSq.DiffTest: Chi-bar-square difference test of the RI-CLPM versus the CLPM and more general.}},
+  author = {Rebecca M. Kuiper},
+  year = {2020},
+  note = {R package version 0.0.0.9000},
+}
+  
+@article{Mulder2020,
+  author = {Jeroen D. Mulder and Ellen L. Hamaker},
+  title = {Three Extensions of the Random Intercept Cross-Lagged Panel Model},
+  journal = {Structural Equation Modeling: A Multidisciplinary Journal},
+  year  = {2020},
+  publisher = {Routledge},
+  doi = {10.1080/10705511.2020.1784738},
+  URL = {https://doi.org/10.1080/10705511.2020.1784738},
+  eprint = {https://doi.org/10.1080/10705511.2020.1784738}
+}

--- a/index.rmd
+++ b/index.rmd
@@ -1,16 +1,13 @@
 ---
 title: "The RI-CLPM & Extensions"
-author: '[Jeroen Mulder](https://www.uu.nl/medewerkers/JDMulder) and [Ellen Hamaker](https://www.uu.nl/medewerkers/ELHamaker) 
+author: '[Jeroen Mulder](https://www.uu.nl/medewerkers/JDMulder) and [Ellen Hamaker](https://www.uu.nl/medewerkers/ELHamaker)
   - Utrecht University, the Netherlands'
 bibliography: p-references.bib
 ---
 
 ----
 
-### The Random Intercept Cross-Lagged Panel Model
-The random intercept cross-lagged panel model (RI-CLPM) is rapidly gaining popularity as a structural equation modeling approach to longitudinal data. It allows for the decomposition of observed scores into within-person dynamics and between-person differences. 
-
-This website is a supplement to "Three Extensions of the Random Intercept Cross-Lagged Panel Model" by Mulder and Hamaker (under review). It contains Mplus syntax and *lavaan* code for specifying the basic RI-CLPM and the following three extensions:
+This website is a supplement to "Three Extensions of the Random Intercept Cross-Lagged Panel Model" by @Mulder2020. It contains Mplus syntax and *lavaan* code for specifying the basic RI-CLPM and the following three extensions:
 
 1. including a time-invariant predictor and outcome,
 2. doing multiple group analysis, and

--- a/lavaan.Rmd
+++ b/lavaan.Rmd
@@ -90,7 +90,7 @@ RICLPM <- '
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -146,7 +146,7 @@ summary(CLPM.fit, standardized = T)
 ---
 
 ### Constraints over time
-Imposing constraints to the model can be achieved through **pre-multiplication**. It means that we have to prepend the number that we want to fix the parameter to, and an asterisk, to the parameter in the model specification. For example, `F =~ 0*x1` fixes the factor loading of item `x1` to factor `F` to 0. Using pre-multiplication we can also constrain parameters to be the same by giving them the same label. Below we specify a RI-CLPM with the following constraints: 
+Imposing constraints to the model can be achieved through **pre-multiplication**. It means that we have to prepend the number that we want to fix the parameter to, and an asterisk, to the parameter in the model specification. For example, `F =~ 0*x1` fixes the factor loading of item `x1` to factor `F` to 0. Using pre-multiplication we can also constrain parameters to be the same by giving them the same label. Below we specify an RI-CLPM with the following constraints: 
 
 1) fixed auto-regressive and cross-lagged relations over time, `wx2 ~ a*wx1 + b*wy1; ...`, 
 2) time-invariant (residual) (co-)variances in the within-person part `wx2 ~~ cov*wy2; ...`, `wx2 ~~ vx*wx2; ...`, and `wy2 ~~ vy*wy2; ...`, and 
@@ -187,7 +187,7 @@ RICLPM1 <- '
   # Estimate the covariance between the within-person centered variables at the first wave. 
   wx1 ~~ wy1 # Covariance
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -246,7 +246,7 @@ RICLPM2 <- '
   # Estimate the covariance between the within-person centered variables at the first wave. 
   wx1 ~~ wy1 # Covariance
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -305,7 +305,7 @@ RICLPM3 <- '
   # Estimate the covariance between the within-person centered variables at the first wave. 
   wx1 ~~ wy1 # Covariance
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -368,7 +368,7 @@ RICLPM5 <- '
   # Estimate the covariance between the within-person centered variables at the first wave. 
   wx1 ~~ wy1 # Covariance
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -404,7 +404,7 @@ Use the tabs below to navigate to the model specification of the RI-CLPM with
 * within components predicting a time-invariant outcome $z_{2}$.
 
 ### $z_{1}$ predicting observed
-Below you can find the code for a RI-CLPM with 5 waves and a time-invariant predictor $z_{1}$ for the observed variables. The effect of $z_{1}$ on the observed variables is constrained to be the same across waves.
+Below you can find the code for an RI-CLPM with 5 waves and a time-invariant predictor $z_{1}$ for the observed variables. The effect of $z_{1}$ on the observed variables is constrained to be the same across waves.
 
 ```{r RICLPM-Z, eval = F}
 RICLPM.ext1 <- '
@@ -443,7 +443,7 @@ RICLPM.ext1 <- '
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -467,12 +467,20 @@ summary(RICLPM.ext1.fit, standardized = T)
 ---
 
 ### $z_{1}$ predicting RIs
-Below you can find the code for a RI-CLPM with 5 waves and a time-invariant predictor $z_{1}$ for the random intercepts. 
+Below you can find the code for an RI-CLPM with 5 waves and a time-invariant predictor $z_{1}$ for the random intercepts. 
 ```{r RICLPM-Z1, eval = F}
 RICLPM1.ext1 <- '
   # Create between components (random intercepts)
   RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
   RIy =~ 1*y1 + 1*y2 + 1*y3 + 1*y4 + 1*y5
+  
+  # Estimate the variance and covariance of the random intercepts. 
+  RIx ~~ RIx
+  RIy ~~ RIy
+  RIx ~~ RIy
+  
+  # Regression of random intercepts on z1. 
+  RIx + RIy ~ z1 # Constrained over time. 
   
   # Create within-person centered variables
   wx1 =~ 1*x1
@@ -485,10 +493,6 @@ RICLPM1.ext1 <- '
   wy3 =~ 1*y3
   wy4 =~ 1*y4
   wy5 =~ 1*y5
-  
-  # Regression of random intercepts on z1. 
-  RIx ~ z1 
-  RIy ~ z1 
   
   # Estimate the lagged effects between the within-person centered variables.
   wx2 + wy2 ~ wx1 + wy1
@@ -504,11 +508,6 @@ RICLPM1.ext1 <- '
   wx3 ~~ wy3
   wx4 ~~ wy4
   wx5 ~~ wy5
-  
-  # Estimate the variance and covariance of the individual factors. 
-  RIx ~~ RIx
-  RIy ~~ RIy
-  RIx ~~ RIy
   
   # Estimate the (residual) variance of the within-person centered variables.
   wx1 ~~ wx1 # Variances
@@ -529,11 +528,134 @@ summary(RICLPM1.ext1.fit, standardized = T)
 ---
 
 ### RI's predicting $z_{2}$
-*lavaan* code will arrive soon for this model.
+Below you can find code for an RI-CLPM with the between components (the random intercepts) predicting a time-invariant outcome. For sake of completeness, the time-invariant $z_{1}$ is also included as a predictor the for observed variables (constrained).
 
+```{r RICLPM-Z3, eval = F}
+RICLPM3.ext1 <- '
+  # Create between components (random intercepts)
+  RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
+  RIy =~ 1*y1 + 1*y2 + 1*y3 + 1*y4 + 1*y5
+  
+  # Estimate the variance and covariance of the random intercepts. 
+  RIx ~~ RIx
+  RIy ~~ RIy
+  RIx ~~ RIy
+  
+  # Regression of time-invariant outcome z2 on random intercepts.
+  z2 ~ RIx + RIy
+  z2 ~~ z2 # Residual variance z2
+  
+  # Create within-person centered variables
+  wx1 =~ 1*x1
+  wx2 =~ 1*x2
+  wx3 =~ 1*x3 
+  wx4 =~ 1*x4
+  wx5 =~ 1*x5
+  wy1 =~ 1*y1
+  wy2 =~ 1*y2
+  wy3 =~ 1*y3
+  wy4 =~ 1*y4
+  wy5 =~ 1*y5
+  
+  # Regression of observed variables on z1 (constrained). 
+  x1 + x2 + x3 + x4 + x5 ~ s1*z1 # Constrained over time. 
+  y1 + y2 + y3 + y4 + y5 ~ s2*z1 # Constrained over time. 
+  
+  # Estimate the lagged effects between the within-person centered variables.
+  wx2 + wy2 ~ wx1 + wy1
+  wx3 + wy3 ~ wx2 + wy2
+  wx4 + wy4 ~ wx3 + wy3
+  wx5 + wy5 ~ wx4 + wy4
+  
+  # Estimate the covariance between the within-person centered variables at the first wave. 
+  wx1 ~~ wy1 # Covariance
+  
+  # Estimate the covariances between the residuals of the within-person centered variables (the innovations).
+  wx2 ~~ wy2
+  wx3 ~~ wy3
+  wx4 ~~ wy4
+  wx5 ~~ wy5
+  
+  # Estimate the (residual) variance of the within-person centered variables.
+  wx1 ~~ wx1 # Variances
+  wy1 ~~ wy1 
+  wx2 ~~ wx2 # Residual variances
+  wy2 ~~ wy2 
+  wx3 ~~ wx3 
+  wy3 ~~ wy3 
+  wx4 ~~ wx4 
+  wy4 ~~ wy4 
+  wx5 ~~ wx5
+  wy5 ~~ wy5
+'
+RICLPM3.ext1.fit <- lavaan(RICLPM3.ext1, data = datZ, missing = 'ML', meanstructure = T, int.ov.free = T) 
+summary(RICLPM3.ext1.fit, standardized = T)
+```
 
 ### Within predicting $z_{2}$
-*lavaan* code will arrive soon for this model.
+Below you can find code for an RI-CLPM with the within components predicting a time-invariant outcome. For sake of completeness, the time-invariant $z_{1}$ is also included as a predictor the for observed variables (constrained).
+
+```{r RICLPM-Z4, eval = F}
+RICLPM4.ext1 <- '
+  # Create between components (random intercepts)
+  RIx =~ 1*x1 + 1*x2 + 1*x3 + 1*x4 + 1*x5
+  RIy =~ 1*y1 + 1*y2 + 1*y3 + 1*y4 + 1*y5
+  
+  # Estimate the variance and covariance of the random intercepts. 
+  RIx ~~ RIx
+  RIy ~~ RIy
+  RIx ~~ RIy
+  
+  # Regression of time-invariant outcome z2 on within components.
+  z2 ~ wx1 + wx2 + wx3 + wx4 + wx5 + wy1 + wy2 + wy3 + wy4 + wy5
+  z2 ~~ z2 # Residual variance z2
+  
+  # Create within-person centered variables
+  wx1 =~ 1*x1
+  wx2 =~ 1*x2
+  wx3 =~ 1*x3 
+  wx4 =~ 1*x4
+  wx5 =~ 1*x5
+  wy1 =~ 1*y1
+  wy2 =~ 1*y2
+  wy3 =~ 1*y3
+  wy4 =~ 1*y4
+  wy5 =~ 1*y5
+  
+  # Regression of observed variables on z1 (constrained). 
+  x1 + x2 + x3 + x4 + x5 ~ s1*z1 # Constrained over time. 
+  y1 + y2 + y3 + y4 + y5 ~ s2*z1 # Constrained over time. 
+  
+  # Estimate the lagged effects between the within-person centered variables.
+  wx2 + wy2 ~ wx1 + wy1
+  wx3 + wy3 ~ wx2 + wy2
+  wx4 + wy4 ~ wx3 + wy3
+  wx5 + wy5 ~ wx4 + wy4
+  
+  # Estimate the covariance between the within-person centered variables at the first wave. 
+  wx1 ~~ wy1 # Covariance
+  
+  # Estimate the covariances between the residuals of the within-person centered variables (the innovations).
+  wx2 ~~ wy2
+  wx3 ~~ wy3
+  wx4 ~~ wy4
+  wx5 ~~ wy5
+  
+  # Estimate the (residual) variance of the within-person centered variables.
+  wx1 ~~ wx1 # Variances
+  wy1 ~~ wy1 
+  wx2 ~~ wx2 # Residual variances
+  wy2 ~~ wy2 
+  wx3 ~~ wx3 
+  wy3 ~~ wy3 
+  wx4 ~~ wx4 
+  wy4 ~~ wy4 
+  wx5 ~~ wx5
+  wy5 ~~ wy5
+'
+RICLPM4.ext1.fit <- lavaan(RICLPM4.ext1, data = datZ, missing = 'ML', meanstructure = T, int.ov.free = T) 
+summary(RICLPM4.ext1.fit, standardized = T)
+```
 
 ## Ext. 2: multiple group {.tabset .tabset-fade}
 Use the tabs below to navigate to the model specification of the basic multiple-group model, or the model with constrained lagged parameters (and intercepts across groups). 
@@ -572,7 +694,7 @@ RICLPM.ext2 <- '
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy
@@ -635,7 +757,7 @@ RICLPM1.ext2 <- '
   wx4 ~~ wy4
   wx5 ~~ wy5
   
-  # Estimate the variance and covariance of the individual factors. 
+  # Estimate the variance and covariance of the random intercepts. 
   RIx ~~ RIx
   RIy ~~ RIy
   RIx ~~ RIy

--- a/p-references.bib
+++ b/p-references.bib
@@ -763,3 +763,14 @@ title = {{From Data to Causes II: Comparing Approaches to Panel Data Analysis}},
 url = {http://journals.sagepub.com/doi/10.1177/1094428119847280},
 year = {2019}
 }
+
+@article{Mulder2020,
+  author = {Jeroen D. Mulder and Ellen L. Hamaker},
+  title = {Three Extensions of the Random Intercept Cross-Lagged Panel Model},
+  journal = {Structural Equation Modeling: A Multidisciplinary Journal},
+  year  = {2020},
+  publisher = {Routledge},
+  doi = {10.1080/10705511.2020.1784738},
+  URL = {https://doi.org/10.1080/10705511.2020.1784738},
+  eprint = {https://doi.org/10.1080/10705511.2020.1784738}
+}

--- a/references.bib
+++ b/references.bib
@@ -7,7 +7,8 @@
 	Edition = {Eighth Edition},
 	Organization = {Muth{\'e}n & Muth{\'e}n},
 	Title = {Mplus User's Guide},
-	Year = {2017}}
+	Year = {2017}
+}
 
 @article{lavaan,
 	Author = {Yves Rosseel},
@@ -18,7 +19,8 @@
 	Url = {http://www.jstatsoft.org/v48/i02/},
 	Volume = {48},
 	Year = {2012},
-	Bdsk-Url-1 = {http://www.jstatsoft.org/v48/i02/}}
+	Bdsk-Url-1 = {http://www.jstatsoft.org/v48/i02/}
+}
 
 @article{Meredith1993,
 	abstract = {Several concepts are introduced and defined: measurement invariance, structural bias, weak measurement invariance, strong factorial invariance, and strict factorial 			invariance. It is shown that factorial invariance has implications for (weak) measurement invariance. Definitions of fairness in employment/admissions testing and salary equity 				are provided and it 	is argued that strict factorial invariance is required for fairness/equity to exist. Implications for item and test bias are developed and it is argued that item or test bias probably depends on the existence of latent variables that are irrelevant to the primary goal of test constructers. {\textcopyright} 1993 The Psychometric Society.},
@@ -28,7 +30,8 @@
 	journal = {Psychometrika},
 	keywords = {equity,factor analysis,factorial invariance,fairness,group differences,item bias,measurement invariance,selection,test bias},
 	title = {{Measurement invariance, factor analysis and factorial invariance}},
-	year = {1993}}
+	year = {1993}
+}
 
 @manual{tidyverse,
 	Author = {Hadley Wickham},
@@ -36,7 +39,8 @@
 	Title = {tidyverse: Easily Install and Load the 'Tidyverse'},
 	Url = {https://CRAN.R-project.org/package=tidyverse},
 	Year = {2017},
-	Bdsk-Url-1 = {https://CRAN.R-project.org/package=tidyverse}}
+	Bdsk-Url-1 = {https://CRAN.R-project.org/package=tidyverse}
+}
 	
 @article{Stoel2006,
   abstract = {The authors show how the use of inequality constraints on parameters in structural equation models may affect the distribution of the likelihood ratio test. Inequality constraints are implicitly used in the testing of commonly applied structural equation models, such as the common factor model, the autoregressive model, and the latent growth curve model, although this is not commonly acknowledged. Such constraints are the result of the null hypothesis in which the parameter value or values are placed on the boundary of the parameter space. For instance, this occurs in testing whether the variance of a growth parameter is significantly different from 0. It is shown that in these cases, the asymptotic distribution of the chi-square difference cannot be treated as that of a central chi-square-distributed random variable with degrees of freedom equal to the number of constraints. The correct distribution for testing 1 or a few parameters at a time is inferred for the 3 structural equation models mentioned above. Subsequently, the authors describe and illustrate the steps that one should take to obtain this distribution. An important message is that using the correct distribution may lead to appreciably greater statistical power. {\textcopyright} 2006 APA, all rights reserved.},
@@ -54,9 +58,19 @@
 }
 
 @Manual{Kuiper2020,
-    title = {{ChiBarSq.DiffTest: Chi-bar-square difference test of the RI-CLPM versus the CLPM
-and more general.}},
-    author = {Rebecca M. Kuiper},
-    year = {2020},
-    note = {R package version 0.0.0.9000},
-  }
+  title = {{ChiBarSq.DiffTest: Chi-bar-square difference test of the RI-CLPM versus the CLPM and more general.}},
+  author = {Rebecca M. Kuiper},
+  year = {2020},
+  note = {R package version 0.0.0.9000},
+}
+  
+@article{Mulder2020,
+  author = {Jeroen D. Mulder and Ellen L. Hamaker},
+  title = {Three Extensions of the Random Intercept Cross-Lagged Panel Model},
+  journal = {Structural Equation Modeling: A Multidisciplinary Journal},
+  year  = {2020},
+  publisher = {Routledge},
+  doi = {10.1080/10705511.2020.1784738},
+  URL = {https://doi.org/10.1080/10705511.2020.1784738},
+  eprint = {https://doi.org/10.1080/10705511.2020.1784738}
+}


### PR DESCRIPTION
Added reference to paper by Mulder and Hamaker (2020). Included lavaan-code for extension 1 with time-invariant outcomes.