### PR TITLE
Fix readme link to the new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RI-CLPM & Extensions
 
-This repository and its Github Pages have been moved to [jeroendmulder.github.io/RI-CLPM](jeroendmulder.github.io/RI-CLPM). This repository's Github Page now serves as an automatic redirect. 
+This repository and its Github Pages have been moved to [jeroendmulder.github.io/RI-CLPM](https://jeroendmulder.github.io/RI-CLPM). This repository's Github Page now serves as an automatic redirect. 
 
 


### PR DESCRIPTION
If https prefix is not added, markdown assumes the link to be relative. This makes the current reference invalid. This PR changes the reference to be an absolute link instead. 